### PR TITLE
Parse array to query string

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /src/vendor/**
 /build/phpUnit/**
 !.gitignore
+.idea

--- a/src/Request/SlimRequest.php
+++ b/src/Request/SlimRequest.php
@@ -87,7 +87,7 @@ class SlimRequest implements RequestInterface
             $host[0],
             (int) $host[1],
             $request->getPath(),
-            $request->getQuery()
+            http_build_query($request->getQuery())
         );
 
         $serverParams                    = $_SERVER;


### PR DESCRIPTION
Show php notice when send parameters in query string.

It was not possible get query string parameters before this change

NOTICE: array to string conversion in Slim\Slim\Http\Uri.php line 798